### PR TITLE
Tidy of signature verification

### DIFF
--- a/src/shares.rs
+++ b/src/shares.rs
@@ -140,9 +140,9 @@ mod tests {
 
         let slip_sig = sks.public_keys().combine_signatures(shares).unwrap();
 
-        let result = voter.verify_slip_signature(&slip, &slip_sig, &sks.public_keys().public_key());
+        let result = voter.verify_signature_on_slip(&slip, &slip_sig, &sks.public_keys().public_key());
 
-        assert!(result.is_ok());
+        assert!(result);
 
         Ok(())
     }


### PR DESCRIPTION
The main change is moving `verify_signature` into two functions `verify_signature_on_slip` and `verify_signature_on_envelope`.

Later I hope to be able to replace most of the util functions with yet-to-be-added blsttc utils, but blsttc is doesn't have the code for this yet! Hopefully soon.

Notes from commit body:

- correctly verify the signature of Envelope and Slip, since the method
  for verification differs for these two signatures
- return bool instead of Result to match blsttc verification response
- rename signature_for_X to signature_on_X for a stronger metaphor, it's
  literally on the slip/envelope, not just for the slip/envelope
- rename verify_X_signature to verify_signature_on_X for a stronger
  metaphor, maybe this is a bit too pedantic / stylistic!
- remove an unwrap when a result was being returned
- added tests to indicate how signatures can be / cannot be unblinded
  and verified
- updated the comment for sign_g2 function to explain why it exists here
  instead of using the blsttc equivalent within SecretKey